### PR TITLE
Fix RSS for Zola 0.11.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,8 @@ description = "placeholder description text for your blog!"
 default_language = "en"
 
 # Whether to generate a RSS feed automatically
-generate_rss = true
+generate_feed = true
+feed_filename = "rss.xml"
 
 # Theme name to use.
 # NOTE: should not need to mess with this if you are using zerm directly, i.e. cloning the

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "scripts":
     {
-        "install": "curl -L -O https://github.com/getzola/zola/releases/download/v0.8.0/zola-v0.8.0-x86_64-unknown-linux-gnu.tar.gz && tar -xzf zola-v0.8.0-x86_64-unknown-linux-gnu.tar.gz",
+        "install": "curl -L -O https://github.com/getzola/zola/releases/download/v0.11.0/zola-v0.11.0-x86_64-unknown-linux-gnu.tar.gz && tar -xzf zola-v0.11.0-x86_64-unknown-linux-gnu.tar.gz",
         "build": "./zola build"
     }
 }

--- a/templates/macros/head.html
+++ b/templates/macros/head.html
@@ -26,7 +26,7 @@
 {% endmacro favicon %}
 
 {% macro rss() %}
-    {%- if config.generate_rss -%}
+    {%- if config.generate_feed -%}
         <link rel="alternate" type="application/rss+xml" title="{{ config.title }} RSS" href="{{ get_url(path="rss.xml") }}">
     {%- endif -%}
 {% endmacro rss %}

--- a/templates/macros/posts.html
+++ b/templates/macros/posts.html
@@ -3,7 +3,7 @@
         <span class="post-date">
             
             {%- if section.extra["date"] -%}
-                {{ section.extra["date"]["$__toml_private_datetime"] | date(format="%Y.%m.%d") }}
+                {{ section.extra["date"] | date(format="%Y.%m.%d") }}
                 {# end of section.date if-check #}
             {%- endif -%}
         </span>
@@ -35,7 +35,7 @@
             disp_cat=config.extra.show_categories,
             disp_tag=config.extra.show_tags) }}
     </div>
-{% endmacro section_meta %}
+{% endmacro meta %}
 
 {% macro taxonomies(taxonomy, disp_cat, disp_tag) %}
 


### PR DESCRIPTION
The [documentation for Zola](https://www.getzola.org/documentation/templates/feeds/) documents a `generate_feed` setting. Switch to that causes RSS to be generated. I also removed workaround for date parsing problem ( getzola/zola#238 ) fixed in 0.11. This was preventing the site from building.