### PR TITLE
Render page.updated field if specified

### DIFF
--- a/content/fiz/index.md
+++ b/content/fiz/index.md
@@ -2,7 +2,6 @@
 title="fiz"
 description="a basic demo of zola. Does it work?"
 date=2019-03-25
-updated=2021-02-03
 author="elias"
 
 [taxonomies]

--- a/content/fiz/index.md
+++ b/content/fiz/index.md
@@ -2,6 +2,7 @@
 title="fiz"
 description="a basic demo of zola. Does it work?"
 date=2019-03-25
+updated=2021-02-03
 author="elias"
 
 [taxonomies]

--- a/content/zerm/index.md
+++ b/content/zerm/index.md
@@ -2,6 +2,7 @@
 title="what is zerm?"
 description="a summary of what zerm is and why it is different."
 date=2019-08-07
+updated=2021-02-03
 
 [taxonomies]
 tags = ["rust", "test", "zola"]

--- a/templates/macros/posts.html
+++ b/templates/macros/posts.html
@@ -23,6 +23,11 @@
                 {{ page.date | date(format="%Y.%m.%d") }}
                 {# end of page.date if-check #}
             {%- endif -%}
+
+            {%- if page.updated -%}
+                [Updated: {{ page.updated | date(format="%Y.%m.%d") }}]
+                {# end of page.updated if-check #}
+            {%- endif -%}
         </span>
 
         <span class="post-author">


### PR DESCRIPTION
### Added

* Add `page.updated` rendering demonstration by editing `content/zerm/index.md`.

### Changed

* Append `[Updated: YYYY.MM.DD]` to post date if the `page.updated` field is set. This mimics the behavior of the original Terminal theme ([upstream example](https://hugo-terminal.now.sh/about)).