### PR TITLE
Add support for summaries, instead of just descriptions.

### DIFF
--- a/templates/macros/lists.html
+++ b/templates/macros/lists.html
@@ -19,9 +19,11 @@
             {%  if page.description -%}
             {{ page.description }}
             {#- end if-check for description -#}
+            {%  elif page.summary -%}
+            {{ page.summary | safe }}
             {%  endif -%}
         </div>
-        {% if page.description -%}
+        {% if page.description or page.summary -%}
         <div>
             <a class="read-more button" href="{{ page.permalink }}">{{ config.extra.read_more }} →</a>
         </div>


### PR DESCRIPTION
As it says on the tin - coming from after-dark, I realized that Zerm doesn't utilize the native summary capabilities provided by Zola. So I added support.

This simply attempts to use the summary (if it's present) and the user hasn't specified a `description` in their top matter.