### PR TITLE
Add font-family:swap for better rendering performance.

### DIFF
--- a/sass/_font.scss
+++ b/sass/_font.scss
@@ -2,6 +2,7 @@
     font-family: 'Fira Code';
     font-style:  normal;
     font-weight: 400;
+    font-display: swap;
     src: url("assets/fonts/FiraCode-Regular.woff") format("woff");
 }
 
@@ -9,5 +10,6 @@
     font-family: 'Fira Code';
     font-style:  normal;
     font-weight: 800;
+    font-display: swap;
     src: url("assets/fonts/FiraCode-Bold.woff") format("woff");
 }


### PR DESCRIPTION
Identified by Pagespeed/Lighthouse, see documentation for fix here:
https://web.dev/avoid-invisible-text/

Personally, this took my Pagespeed score from 99 to 100, for whatever that's worth.