### PR TITLE
Support Atom *and* RSS feeds, instead of only RSS.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,7 +12,10 @@ default_language = "en"
 
 # Whether to generate a RSS feed automatically
 generate_feed = true
-feed_filename = "rss.xml"
+# 'atom.xml' (default if unspecified) and 'rss.xml' are officially supported
+# values for feed_filename in this theme. All other filenames will assume a
+# link type of 'application/rss+xml'.
+# feed_filename = "atom.xml"
 
 # Theme name to use.
 # NOTE: should not need to mess with this if you are using zerm directly, i.e. cloning the

--- a/templates/macros/head.html
+++ b/templates/macros/head.html
@@ -27,7 +27,7 @@
 
 {% macro rss() %}
     {%- if config.generate_feed -%}
-        <link rel="alternate" type="application/rss+xml" title="{{ config.title }} RSS" href="{{ get_url(path="rss.xml") }}">
+        <link rel="alternate" type={% if config.feed_filename == "atom.xml" %}"application/atom+xml"{% else %}"application/rss+xml"{% endif %} title="{{ config.title }} RSS" href="{{ get_url(path=config.feed_filename) }}">
     {%- endif -%}
 {% endmacro rss %}
 


### PR DESCRIPTION
Atom is the default in Zola, so now the feed link properly changes based
on the feed filename.

The idea and much of the implementation for this were taken from the
after-dark theme.

Update: I realize that the core `config.toml` in this project can be updated to suggest that the `feed_filename = rss.xml` change is optional now.