### PR TITLE
Add cachebusting for CSS.

### DIFF
--- a/templates/macros/footer.html
+++ b/templates/macros/footer.html
@@ -10,5 +10,5 @@
 {% endmacro copyright %}
 
 {% macro script() %}
-    <script type="text/javascript" src="{{ get_url(path="assets/js/main.js" ) }}"></script>
+    <script type="text/javascript" src="{{ get_url(path="assets/js/main.js") }}"></script>
 {% endmacro script %}

--- a/templates/macros/head.html
+++ b/templates/macros/head.html
@@ -7,15 +7,15 @@
 -#}
 
 {% macro styling() %}
-    <link rel="stylesheet" href="{{ get_url(path="style.css") }}">
+    <link rel="stylesheet" href="{{ get_url(path="style.css", cachebust=true) }}">
     {% if config.extra.theme_color != "orange" -%}
         {% set color = "color/" ~ config.extra.theme_color ~ ".css" -%}
-        <link rel="stylesheet" href="{{ get_url(path=color) }}">
+        <link rel="stylesheet" href="{{ get_url(path=color, cachebust=true) }}">
     {%- else -%}
-        <link rel="stylesheet" href=" {{ get_url(path="color/orange.css") }}">
+        <link rel="stylesheet" href=" {{ get_url(path="color/orange.css", cachebust=true) }}">
     {% endif %}
     {%- if config.extra.custom_css is defined -%}
-        <link rel="stylesheet" href="{{ get_url(path="custom.css") }}">
+        <link rel="stylesheet" href="{{ get_url(path="custom.css", cachebust=true) }}">
     {% endif %}
 {% endmacro styling %}
 


### PR DESCRIPTION
This allows users to set extremely high caching values for their CSS
assets without worrying about poor UX whenever an update to said
assets is made.

Note: Can't add this for JS assets yet, the cachebusting logic is
broken, see https://github.com/getzola/zola/issues/1416

Ref:
* https://www.getzola.org/documentation/templates/overview/#get-url
* https://github.com/getzola/zola/issues/519