### PR TITLE
Fix newline that was generated in the og:title property

### DIFF
--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -26,7 +26,7 @@
     {%- endif -%}
 {% endmacro og_description %}
 
-{% macro og_title() %}
+{% macro og_title() -%}
     {{ config.title }} -&nbsp;
     {%- if section -%}
         {%- if section.title -%}


### PR DESCRIPTION
Pretty much as the title says - the resulting HTML has a newline at the very beginning of the `og:title` tag. This fixes it.