### PR TITLE
Semantic html

### DIFF
--- a/sass/_semantic.scss
+++ b/sass/_semantic.scss
@@ -1,0 +1,3 @@
+section, article, aside, footer, header, nav {
+    display: block;
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -6,3 +6,4 @@
 @import 'post';
 @import 'pagination';
 @import 'footer';
+@import 'semantic';

--- a/templates/macros/lists.html
+++ b/templates/macros/lists.html
@@ -4,9 +4,11 @@
     {%- for page in paginator.pages -%}
     
     <div class="post on-list">
-        <h1 class="post-title">
-            <a href="{{ page.permalink }}">{{ page.title }}</a>
-        </h1>
+        <header>
+            <h1 class="post-title">
+                <a href="{{ page.permalink }}">{{ page.title }}</a>
+            </h1>
+        </header>
         
         
         {{ posts::meta(page=page, author=config.extra.show_author) }}

--- a/templates/macros/lists.html
+++ b/templates/macros/lists.html
@@ -1,5 +1,5 @@
 {% macro list_pages() %}
-<div class="posts">
+<section class="posts">
     
     {%- for page in paginator.pages -%}
     
@@ -33,5 +33,5 @@
     {%- endfor -%}
     {#- I don't put pagination here like Terminal does. I don't like how
     the buttons move with the size of post entries in the content div. -#}
-</div>
+</section>
 {% endmacro list_pages %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -19,6 +19,6 @@
 
             {{ page.content | safe }}
         {# TODO: Decide if any sort of commenting functionality is desired? #}
-    {#%- include "snippets/comments.html"  -%#}
+        {#%- include "snippets/comments.html"  -%#}
     </article>
 {%- endblock main -%}

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,12 +7,12 @@
 {%- endblock title -%}
 
 {%- block main -%}
-    <div class="post">
         <h1 class="post-title">
             <a href="{{ page.permalink  }}">{{ page.title }}</a>
         </h1>
         {{ posts::meta(page=page, author=config.extra.show_author) }}
 
+    <article class="post">
 
         {#- Skipping logic for cover as was in original Terminal theme -#}
 
@@ -21,5 +21,5 @@
         </div>
         {# TODO: Decide if any sort of commenting functionality is desired? #}
     {#%- include "snippets/comments.html"  -%#}
-</div>
+    </article>
 {%- endblock main -%}

--- a/templates/page.html
+++ b/templates/page.html
@@ -17,9 +17,7 @@
 
         {#- Skipping logic for cover as was in original Terminal theme -#}
 
-        <div class="post-content">
             {{ page.content | safe }}
-        </div>
         {# TODO: Decide if any sort of commenting functionality is desired? #}
     {#%- include "snippets/comments.html"  -%#}
     </article>

--- a/templates/page.html
+++ b/templates/page.html
@@ -7,12 +7,13 @@
 {%- endblock title -%}
 
 {%- block main -%}
-        <h1 class="post-title">
-            <a href="{{ page.permalink  }}">{{ page.title }}</a>
-        </h1>
-        {{ posts::meta(page=page, author=config.extra.show_author) }}
-
     <article class="post">
+        <header>
+            <h1 class="post-title">
+                <a href="{{ page.permalink  }}">{{ page.title }}</a>
+            </h1>
+            {{ posts::meta(page=page, author=config.extra.show_author) }}
+        </header>
 
         {#- Skipping logic for cover as was in original Terminal theme -#}
 

--- a/templates/section.html
+++ b/templates/section.html
@@ -7,21 +7,18 @@
 {%- endblock title -%}
 
 {%- block main -%}
-<div class="post">
-    <header>
-        <h1 class="post-title">
-            <a href="{{ section.permalink  }}">{{ section.title }}</a>
-        </h1>
-    </header>
-    
-    {{ posts::section_meta(section=section, author=config.extra.show_author) }}
+    <article class="post">
+        <header>
+            <h1 class="post-title">
+                <a href="{{ section.permalink  }}">{{ section.title }}</a>
+            </h1>
+            {{ posts::section_meta(section=section, author=config.extra.show_author) }}
+        </header>
 
-    {#- Skipping logic for cover as was in original Terminal theme -#}
+        {#- Skipping logic for cover as was in original Terminal theme -#}
 
-    <div class="post-content">
-        {{ section.content | safe }}
-    </div>
-    {# TODO: Decide if any sort of commenting functionality is desired? #}
-    {#%- include "snippets/comments.html"  -%#}
-</div>
+            {{ section.content | safe }}
+        {# TODO: Decide if any sort of commenting functionality is desired? #}
+        {#%- include "snippets/comments.html"  -%#}
+    </article>
 {%- endblock main -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -8,9 +8,11 @@
 
 {%- block main -%}
 <div class="post">
-    <h1 class="post-title">
-        <a href="{{ section.permalink  }}">{{ section.title }}</a>
-    </h1>
+    <header>
+        <h1 class="post-title">
+            <a href="{{ section.permalink  }}">{{ section.title }}</a>
+        </h1>
+    </header>
     
     {{ posts::section_meta(section=section, author=config.extra.show_author) }}
 


### PR DESCRIPTION
This, at least partially, resolves #3, which asks about using semantic html.

The main template seems to already use some semantic HTML on the main page.

In this PR I've altered the page.html, section.html, and lists macro to add a few semantic html tags. There may be more needed, and I think there is some existing divs that can still be removed, but this will sets up <article> tags for the individual pages and sections, and wrap's each articles header in a <header> tag.