### PR TITLE
Enable disqus

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -116,3 +116,6 @@ read_more = "read more"
 # not currently used from previous theme, but leaving here for now in case I
 # feel like adding it.
 read_other_posts = "read other posts"
+
+# Options for disqus
+disqus = { enabled=true, short_name="" }

--- a/config.toml
+++ b/config.toml
@@ -118,4 +118,4 @@ read_more = "read more"
 read_other_posts = "read other posts"
 
 # Options for disqus
-disqus = { enabled=true, short_name="" }
+disqus = { enabled=false, short_name="" }

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
 {% import "macros/pagination.html" as pagination -%}
 {% import "macros/footer.html" as footer -%}
 {% import "macros/extended_footer.html" as extended_footer -%}
+{% import "macros/comments.html" as comments -%}
 
 <!DOCTYPE html>
 <html lang="{{ config.default_language }}">

--- a/templates/macros/comments.html
+++ b/templates/macros/comments.html
@@ -1,2 +1,30 @@
 {% macro comments() %}
+    {% if config.extra.disqus.enabled is defined and config.extra.disqus.enabled == true %}
+        {{ comments::disqus() }}
+    {% endif %}
 {% endmacro comments %}
+
+
+{% macro disqus() %}
+
+    <div id="disqus_thread"></div>
+    <script>
+        /**
+        *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+        *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables    */
+        
+        var disqus_config = function () {
+            this.page.url = '{{ page.permalink | safe }}';  // Replace PAGE_URL with your page's canonical URL variable
+            this.page.identifier = '{{ page.permalink | safe }}'; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+        };
+        
+        (function() { // DON'T EDIT BELOW THIS LINE
+        var d = document, s = d.createElement('script');
+        s.src = 'https://{{config.extra.disqus.short_name}}.disqus.com/embed.js';
+        s.setAttribute('data-timestamp', +new Date());
+        (d.head || d.body).appendChild(s);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+
+{% endmacro disqus %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -17,7 +17,9 @@
 
         {#- Skipping logic for cover as was in original Terminal theme -#}
 
-            {{ page.content | safe }}
+        {{ page.content | safe }}
+
+        {{ comments::comments() }}
         {# TODO: Decide if any sort of commenting functionality is desired? #}
         {#%- include "snippets/comments.html"  -%#}
     </article>


### PR DESCRIPTION
This resolves #22 and will allow users to easily integrate Disqus. I built it in such a way that other comment platforms can be easily added in addition or instead of.

You can see it in action at the bottom of https://digitalmccullough.com/blog/adopting-remote-unifi-devices-with-windows-server-dhcp/