### PR TITLE
Remove unused CSS.

### DIFF
--- a/sass/_buttons.scss
+++ b/sass/_buttons.scss
@@ -1,9 +1,3 @@
-.button-container {
-  display: table;
-  margin-left: auto;
-  margin-right: auto;
-}
-
 button,
 .button,
 a.button {
@@ -20,43 +14,6 @@ a.button {
   appearance: none;
   cursor: pointer;
   outline: none;
-
-  /* variants */
-
-  &.outline {
-    background: transparent;
-    box-shadow: none;
-    padding: 8px 18px;
-
-    :hover {
-      transform: none;
-      box-shadow: none;
-    }
-  }
-
-  &.primary {
-    box-shadow: 0 4px 6px rgba(50, 50, 93, .11), 0 1px 3px rgba(0, 0, 0, .08);
-
-    &:hover {
-      box-shadow: 0 2px 6px rgba(50, 50, 93, .21), 0 1px 3px rgba(0, 0, 0, .08);
-    }
-  }
-
-  &.link {
-    background: none;
-    font-size: 1rem;
-  }
-
-  /* sizes */
-
-  &.small {
-    font-size: .8rem;
-  }
-
-  &.wide {
-    min-width: 200px;
-    padding: 14px 24px;
-  }
 }
 
 a.read-more,
@@ -70,23 +27,3 @@ a.read-more:active {
   max-width: 100%;
 }
 
-.code-toolbar {
-  margin-bottom: 20px;
-
-  .toolbar-item a {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: 3px 8px;
-    margin-bottom: 5px;
-    text-align: center;
-    font-size: 13px;
-    font-weight: 500;
-    border-radius: 8px;
-    border: 1px solid transparent;
-    appearance: none;
-    cursor: pointer;
-    outline: none;
-  }
-}

--- a/sass/_pagination.scss
+++ b/sass/_pagination.scss
@@ -3,33 +3,6 @@
 .pagination {
   margin-top: 50px;
 
-  &__title {
-    display: flex;
-    text-align: center;
-    position: relative;
-    margin: 100px 0 20px;
-
-    &-h {
-      text-align: center;
-      margin: 0 auto;
-      padding: 5px 10px;
-      background: var(--background);
-      font-size: .8rem;
-      text-transform: uppercase;
-      letter-spacing: .1em;
-      z-index: 1;
-    }
-
-    hr {
-      position: absolute;
-      left: 0;
-      right: 0;
-      width: 100%;
-      margin-top: 15px;
-      z-index: 0;
-    }
-  }
-
   &__buttons {
     display: flex;
     align-items: center;

--- a/sass/_post.scss
+++ b/sass/_post.scss
@@ -61,47 +61,8 @@
     }
   }
 
-  // %tags {
-  //   margin-bottom: 20px;
-  //   font-size: 1rem;
-  //   opacity: .5;
-  // }
-
-  &-tags {
-    display: block;
-    margin-bottom: 20px;
-    font-size: 1rem;
-    opacity: .5;
-
-    a {
-        text-decoration: none;
-    }
-  }
-
-  // &-tags-inline {
-  //   @extend %tags;
-
-  //   display: inline;
-
-  //   @media (max-width: $phone-max-width) {
-  //     display: block;
-  //   }
-  // }
-
   &-content {
     margin-top: 30px;
-  }
-
-  &-cover {
-    border: 20px solid var(--accent);
-    background: transparent;
-    margin: 40px 0;
-    padding: 20px;
-
-    @media (max-width: $phone-max-width) {
-      padding: 10px;
-      border-width: 10px;
-    }
   }
 
   ul {
@@ -143,37 +104,3 @@
     }
 }
 
-.post--regulation {
-  h1 {
-    justify-content: center;
-  }
-
-  h2 {
-    justify-content: center;
-    margin-bottom: 10px;
-
-    &+ h2 {
-      margin-top: -10px;
-      margin-bottom: 20px;
-    }
-  }
-}
-
-.post-list {
-  .post-date {
-    color: var(--accent-alpha-70);
-    text-decoration: none;
-  }
-
-  a {
-    text-decoration: none;
-  }
-
-  .post-list-title {
-    text-decoration: underline;
-  }
-
-  .post-tag {
-    text-decoration: underline;
-  }
-}


### PR DESCRIPTION
Based on a scan of my own website using https://www.jitbit.com/unusedcss/,
and manually checking the usage of various classes, it seems that we can
delete a fair amount of CSS, as it's completely unused.

I explicitly left some, as I think it will have uses, especially for
users with image/figure shortcode templates and a few similar elements.

This results is a significant reduction in CSS size for no reduction in
experience (if I did my job right).

Total CSS Size (bytes) Before:
* Uncompressed: 11137
* Compressed (Brotli): 2428

Total CSS Size (bytes) After:
* Uncompressed: 9106
* Compressed (Brotli): 2042

Percent reduction:
* Uncompressed: 18.2365%
* Compressed: 15.8979%