### PR TITLE
Request fonts with valid url

### DIFF
--- a/sass/_font.scss
+++ b/sass/_font.scss
@@ -3,7 +3,7 @@
     font-style:  normal;
     font-weight: 400;
     font-display: swap;
-    src: url("assets/fonts/FiraCode-Regular.woff") format("woff");
+    src: url(data:application/FiraCode-Regular.woff) format("woff");
 }
 
 @font-face {
@@ -11,5 +11,5 @@
     font-style:  normal;
     font-weight: 800;
     font-display: swap;
-    src: url("assets/fonts/FiraCode-Bold.woff") format("woff");
+    src: url(data:application/FiraCode-Bold.woff) format("woff");
 }

--- a/templates/macros/head.html
+++ b/templates/macros/head.html
@@ -32,8 +32,8 @@
 {% endmacro rss %}
 
 {% macro fonts() %}
-    <link rel="preload" href="/assets/fonts/FiraCode-Regular.woff" as="font" type="font/woff" crossorigin>
-    <link rel="preload" href="/assets/fonts/FiraCode-Bold.woff" as="font" type="font/woff" crossorigin>
+    <link rel="preload" href="{{ get_url(path="assets/fonts/FiraCode-Regular.woff") }}" as="font" type="font/woff" crossorigin>
+    <link rel="preload" href="{{ get_url(path="assets/fonts/FiraCode-Bold.woff") }}" as="font" type="font/woff" crossorigin>
 {% endmacro fonts %}
 
 {% macro general_meta() %}


### PR DESCRIPTION
For url with path ( eg. p-inks.github.io/blog ), it requests font from wrong url.  
This fixes the font path to the correct one. 