### PR TITLE
Inline code blocks: no white space breaks

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -168,6 +168,7 @@ code {
   padding: 1px 6px;
   margin: 0 2px;
   font-size: .95rem;
+  white-space: pre;
 }
 
 pre {


### PR DESCRIPTION
Inline code (\`like so\`) has `white-space: normal` set, which makes it break:
`like`
`so`

instead of carrying over to the next line.
`like so`

ref: #46 