### PR TITLE
feat: Add Table of Contents

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -124,3 +124,8 @@ enable_katex = true
 
 # Options for disqus
 disqus = { enabled=false, short_name="" }
+
+# generate Table of Contents for all articles
+# Table of Contents can be generated for individual articles
+# by adding `generate_toc = true` in [extra] section in frontmatter
+# generate_toc = true

--- a/content/zerm/index.md
+++ b/content/zerm/index.md
@@ -9,6 +9,7 @@ tags = ["rust", "test", "zola"]
 categories = ["programming", "misc.",]
 
 [extra]
+generate_toc = true
 +++
 
 # hello

--- a/sass/_header.scss
+++ b/sass/_header.scss
@@ -1,7 +1,6 @@
 @import "variables";
 
 @mixin menu {
-  position: absolute;
   background: var(--background);
   box-shadow: var(--shadow);
   color: var(--color);
@@ -49,6 +48,7 @@
 
     @media (max-width: $phone-max-width) {
         @include menu;
+        position: absolute;
         top: 50px;
         right: 0;
     }

--- a/sass/_toc.scss
+++ b/sass/_toc.scss
@@ -1,0 +1,6 @@
+div.toc {
+	--shadow-color: var(--accent-alpha-70);
+    --shadow: 0 10px var(--shadow-color), -10px 10px var(--shadow-color), 10px 10px var(--shadow-color);
+	@include menu;	
+	margin: 20px 0;
+}

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -7,3 +7,4 @@
 @import 'pagination';
 @import 'footer';
 @import 'semantic';
+@import 'toc';

--- a/templates/macros/toc.html
+++ b/templates/macros/toc.html
@@ -1,0 +1,61 @@
+{% macro toc (t) %}
+<div class="toc" id="nav-container">
+	<p class="toc-head">Table of Contents</p>
+	{% if t %}
+		<div id="nav-content" >
+		<ul>
+		{% for h1 in page.toc %}
+			<li>
+				<a href="{{ h1.permalink | safe }}">{{ h1.title }}</a>
+				{% if h1.children %}
+					<ul>
+						{% for h2 in h1.children %}
+							<li>
+								<a href="{{ h2.permalink | safe }}">{{ h2.title }}</a>
+							</li>
+							{% if h2.children %}
+								<ul>
+								{% for h3 in h2.children %}
+									<li>
+										<a href="{{ h3.permalink | safe }}">{{ h3.title }}</a>
+										{% if h3.children %}
+											<ul>
+												{% for h4 in h3.children %}
+													<li>
+														<a href="{{ h4.permalink | safe }}">{{ h4.title }}</a>
+													</li>
+													{% if h4.children %}
+														<ul>
+															{% for h5 in h4.children %}
+																<li>
+																	<a href="{{ h5.permalink | safe }}">{{ h5.title }}</a>
+																	{% if h5.children %}
+																		<ul>
+																		{% for h6 in h5.children %}
+																			<li>
+																				<a href="{{ h5.permalink | safe }}">{{ h6.title }}</a>
+																			</li>
+																		{% endfor %}
+																		</ul>
+																	{% endif %}
+																</li>
+															{% endfor %}
+														</ul>
+													{% endif %}
+												{% endfor %}
+											</ul>
+										{% endif %}
+									</li>
+								{% endfor %}
+								</ul>
+							{% endif %}
+						{% endfor %}
+					</ul>
+				{% endif %}
+			</li>
+		{% endfor %}
+		</ul>
+		</div>
+	{% endif %}
+</div>
+{% endmacro %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,4 +1,5 @@
 {% import "macros/head.html" as head -%}
+{% import "macros/toc.html" as toc -%}
 {% extends "index.html" -%}
 
 {%- block math -%}
@@ -20,6 +21,12 @@
                 <a href="{{ page.permalink  }}">{{ page.title }}</a>
             </h1>
             {{ posts::meta(page=page, author=config.extra.show_author) }}
+
+            {%- block ToC -%}
+                {%- if page.toc and page.extra.generate_toc or config.extra.generate_toc -%}
+                    {{ toc::toc(t=page.toc) }}
+                {%- endif -%}
+            {%- endblock ToC -%}
         </header>
 
         {#- Skipping logic for cover as was in original Terminal theme -#}


### PR DESCRIPTION
- Flag in article front-matter for `generate_toc = true`
- Alternatively, `generate_toc = true` in `config.toml` to turn on Table of Contents generation for all articles.

I reused some styling from the menu.

Looks something like this:

![image](https://user-images.githubusercontent.com/51814158/154543607-5fbc2ede-45f5-4443-8f3f-3b2b27f6c65a.png)

Alternatively, by changing the styling a bit, we can get a pop-in effect.

![image](https://user-images.githubusercontent.com/51814158/154543056-1652ac91-4a51-4df7-b74a-ed2960a80783.png)
