### PR TITLE
Improved social metadata settings

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -129,3 +129,10 @@ disqus = { enabled=false, short_name="" }
 # Table of Contents can be generated for individual articles
 # by adding `ToC = true` in [extra] section in frontmatter
 # ToC = true
+
+# Twitter metadata
+# the website used in the card footer
+# twitter_site="@username_website"
+# for the actual author of the page
+# (it can be overwrited specifying a custom `twitter_user` in [extra] in frontmatter)
+# twitter_user="@username_user"

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,6 +27,10 @@
             {{ social::og_preview() }}
         {%- endblock og_preview -%}
 
+        {%- block twitter_preview -%}
+            {{ social::twitter_preview() }}
+        {%- endblock twitter_preview -%}
+
         {%- block fonts -%}
             {{ head::fonts() }}
         {%- endblock fonts -%}

--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -18,8 +18,33 @@
         <meta property="og:image" content="{{ get_url(path=config.extra.og_preview_img) }}"/>
         {%- endif -%}
     {%- endif -%}{# ./if section #}
-
 {% endmacro og_preview %}
+
+{% macro twitter_preview() %}
+    {%- if page -%}
+    {% if page.extra.og_image %}
+    <meta name="twitter:card" content="summary_large_image">
+    {% else %}
+    <meta name="twitter:card" content="summary">
+    {%- endif -%}
+    {% else %}
+    <meta name="twitter:card" content="summary">
+    {%- endif -%}
+
+    {% if config.extra.twitter_site -%}
+    <meta name="twitter:site" content="{{ config.extra.twitter_site }}">
+    {%- endif -%}
+
+    {% if page %}
+    {%- if page.extra.twitter_user -%}
+    <meta name="twitter:creator" content="{{ page.extra.twitter_user }}">
+    {%- elif config.extra.twitter_user -%}
+    <meta name="twitter:creator" content="{{ config.extra.twitter_user }}">
+    {%- endif -%}{# ./if page.extra.twitter_user #}
+    {%- elif config.extra.twitter_user %}
+    <meta name="twitter:creator" content="{{ config.extra.twitter_user }}">
+    {%- endif %}{# ./if page #}
+{% endmacro twitter_preview %}
 
 {% macro og_description() %}
     {%- if section -%}

--- a/templates/macros/social.html
+++ b/templates/macros/social.html
@@ -5,9 +5,20 @@
         <meta property="og:url" content="{{ current_url }}"/>
     {%- endif -%}
     <meta property="og:description" content="{{ social::og_description() }}"/>
-    {%- if config.extra.og_preview_img -%}
+
+    {%- if section -%}
+        {%- if config.extra.og_preview_img -%}
         <meta property="og:image" content="{{ get_url(path=config.extra.og_preview_img) }}"/>
-    {%- endif -%}
+        {%- endif -%}
+
+    {%- elif page -%}
+        {%- if page.extra.og_image -%}
+        <meta property="og:image" content="{{ current_url ~ page.extra.og_image | trim }}"/>
+        {%- elif config.extra.og_preview_img -%}
+        <meta property="og:image" content="{{ get_url(path=config.extra.og_preview_img) }}"/>
+        {%- endif -%}
+    {%- endif -%}{# ./if section #}
+
 {% endmacro og_preview %}
 
 {% macro og_description() %}


### PR DESCRIPTION
New optional fields in `config.toml`:
- `twitter_user` (for the author username)
- `twitter_site` (for the website username)

New optional fields in `[extra]` section of page frontmatters:
- `og_image` (if you want a custom image on facebook/twitter/telegram previews for that page)
- `twitter_user` (for the author username; useful for websites with several authors)

Every change is optional and non of them does interfere with other parts of the code. 