### PR TITLE
inline footnotes with designated color

### DIFF
--- a/content/zerm/index.md
+++ b/content/zerm/index.md
@@ -64,4 +64,6 @@ Like zerm? Then [install
 Zola](https://www.getzola.org/documentation/getting-started/installation/) and
 [get started](https://www.getzola.org/documentation/themes/installing-and-using-themes/#installing-a-theme)!
 
+---
+
 [^1]: fork? port? a little bit of the former, more of the latter?

--- a/sass/_post.scss
+++ b/sass/_post.scss
@@ -104,3 +104,11 @@
     }
 }
 
+.footnote-definition {
+  color: var(--accent);
+
+  p {
+    display: inline;
+    color: var(--footnote-color);
+  }
+}

--- a/sass/color/blue.scss
+++ b/sass/color/blue.scss
@@ -5,4 +5,5 @@
   --background: #1D1E28;
   --color: whitesmoke;
   --border-color: rgba(255, 255, 255, .1);
+  --footnote-color: rgba(255, 255, 255, .5);
 }

--- a/sass/color/green.scss
+++ b/sass/color/green.scss
@@ -8,4 +8,5 @@
   --background: #1F222A;
   --color: whitesmoke;
   --border-color: rgba(255, 255, 255, .1);
+  --footnote-color: rgba(255, 255, 255, .5);
 }

--- a/sass/color/orange.scss
+++ b/sass/color/orange.scss
@@ -5,4 +5,5 @@
   --background: #211f1a;
   --color: whitesmoke;
   --border-color: rgba(255, 255, 255, .1);
+  --footnote-color: rgba(255, 255, 255, .5);
 }

--- a/sass/color/pink.scss
+++ b/sass/color/pink.scss
@@ -5,4 +5,5 @@
   --background: #21202C;
   --color: whitesmoke;
   --border-color: rgba(255, 255, 255, .1);
+  --footnote-color: rgba(255, 255, 255, .5);
 }

--- a/sass/color/red.scss
+++ b/sass/color/red.scss
@@ -5,4 +5,5 @@
   --background: #221F29;
   --color: whitesmoke;
   --border-color: rgba(255, 255, 255, .1);
+  --footnote-color: rgba(255, 255, 255, .5);
 }


### PR DESCRIPTION
![preview](https://user-images.githubusercontent.com/56557525/158282206-3ae7261e-8839-4b1d-b437-b2d848089f39.png)

During my update, I remembered to check on Radek Kozieł's Terminal theme: I saw he use accent color for numbers, so I did it too. I think it looks nice.