### PR TITLE
Change _font.scss to use get_url

### DIFF
--- a/sass/_font.scss
+++ b/sass/_font.scss
@@ -3,7 +3,7 @@
     font-style:  normal;
     font-weight: 400;
     font-display: swap;
-    src: url("assets/fonts/FiraCode-Regular.woff2") format("woff2"), url("assets/fonts/FiraCode-Regular.woff") format("woff");
+    src: get_url(path="assets/fonts/FiraCode-Regular.woff2") format("woff2"), get_url(path="assets/fonts/FiraCode-Regular.woff") format("woff");
 }
 
 @font-face {
@@ -11,5 +11,5 @@
     font-style:  normal;
     font-weight: 800;
     font-display: swap;
-    src: url("assets/fonts/FiraCode-Bold.woff2") format("woff2"), url("assets/fonts/FiraCode-Bold.woff") format("woff");
+    src: get_url(path="assets/fonts/FiraCode-Bold.woff2") format("woff2"), get_url(path="assets/fonts/FiraCode-Bold.woff") format("woff");
 }


### PR DESCRIPTION
Was running into a CORS policy error because fonts were being looked up at the wrong url, this change ended up fixing it for me.

I'm not sure if the issue is due to my own hacking on zerm or if this is actually helpful, but figured I'd make the PR in case it was.