### PR TITLE
bugfix/fix render for code blocks with line numbers

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -195,6 +195,24 @@ pre {
       padding: 0;
       font-size: inherit;
       border: none;
+
+      table {
+        table-layout: auto;
+        border-collapse: collapse;
+        box-sizing: border-box;
+        width: 100%;
+        margin: 00px 0;
+      }
+
+      table, th, td {
+        border: none;
+        padding: 0px;
+      }
+
+      table tr td:first-child {
+        padding-right: 10px;
+      }
+
   }
 }
 


### PR DESCRIPTION
Code blocks with linenos enabled becomes tables. Originally, these code blocks would inherit their styling from the global `table` style. I added styling so that the nested table appears more like the original code block by inserting table styling inside the `code` and `pre` styles to override the global table styles.

A comparison can be seen below and is improved compared to #62.

![image](https://user-images.githubusercontent.com/7043297/173480202-869d10d2-3d42-460b-89a0-2db7c89f304a.png)

I added a nominal `padding-right` to the `td:first-child` so the line numbers would have some buffer before the code. Feel free to make this line or any of it better as I am not very familiar with front end development.