### PR TITLE
Use var(--color) as base color for code tag

### DIFF
--- a/sass/_main.scss
+++ b/sass/_main.scss
@@ -191,6 +191,7 @@ pre {
 
     code {
       background: none !important;
+      color: var(--color);
       margin: 0;
       padding: 0;
       font-size: inherit;


### PR DESCRIPTION
There are some Zola highlight themes and syntax definitions that don't work very well, and as such, they sometimes fall back to the base text color provided by the Zola theme. If the base text color is not neutral, e.g. white or black, the code highlighting can look quite terrible, as shown in https://github.com/getzola/zola/issues/1423.

It would be nice if the `code` tag defaulted to `var(--color)` instead of `var(--accent)` to avoid breaking several built-in Zola highlight themes, e.g. `charcoal` on Zola 0.16.1. With that said, if there's enough opposition to this change, it's okay; I'm willing to just override the CSS in my own project to fix the highlight themes.