### PR TITLE
fix: add shortcodes in templates for youtube links

### DIFF
--- a/templates/shortcodes/youtube.html
+++ b/templates/shortcodes/youtube.html
@@ -1,0 +1,5 @@
+<div {% if class %}class="{{class}}" {% endif %}>
+    <iframe src="https://www.youtube.com/embed/{{id}}{% if autoplay %}?autoplay=1{% endif %}" webkitallowfullscreen
+        mozallowfullscreen allowfullscreen>
+    </iframe>
+</div>


### PR DESCRIPTION
Didn't work without shortcodes on my computer, so I added shortcode for YouTube links